### PR TITLE
Removed .old extensions from sevice acount path, Closes #1

### DIFF
--- a/src/main/java/com/example/MyMqtt.java
+++ b/src/main/java/com/example/MyMqtt.java
@@ -55,7 +55,7 @@ public class MyMqtt implements MqttCallback {
     {
         try {
             GoogleCredentials credentials =
-                    GoogleCredentials.fromStream(getClass().getResourceAsStream("/smart-home-key.json.old"));
+                    GoogleCredentials.fromStream(getClass().getResourceAsStream("/smart-home-key.json"));
             actionsApp.setCredentials(credentials);
         } catch (Exception e) {
             LOGGER.error("couldn't load credentials");

--- a/src/main/java/com/example/SmartHomeCreateServlet.java
+++ b/src/main/java/com/example/SmartHomeCreateServlet.java
@@ -49,7 +49,7 @@ public class SmartHomeCreateServlet extends HttpServlet {
   {
     try {
       GoogleCredentials credentials =
-          GoogleCredentials.fromStream(getClass().getResourceAsStream("/smart-home-key.json.old"));
+          GoogleCredentials.fromStream(getClass().getResourceAsStream("/smart-home-key.json"));
       actionsApp.setCredentials(credentials);
     } catch (Exception e) {
       LOGGER.error("couldn't load credentials");

--- a/src/main/java/com/example/SmartHomeDeleteServlet.java
+++ b/src/main/java/com/example/SmartHomeDeleteServlet.java
@@ -47,7 +47,7 @@ public class SmartHomeDeleteServlet extends HttpServlet {
   {
     try {
       GoogleCredentials credentials =
-          GoogleCredentials.fromStream(getClass().getResourceAsStream("/smart-home-key.json.old"));
+          GoogleCredentials.fromStream(getClass().getResourceAsStream("/smart-home-key.json"));
       actionsApp.setCredentials(credentials);
     } catch (Exception e) {
       LOGGER.error("couldn't load credentials");

--- a/src/main/java/com/example/SmartHomeServlet.java
+++ b/src/main/java/com/example/SmartHomeServlet.java
@@ -48,7 +48,7 @@ public class SmartHomeServlet extends HttpServlet {
   {
     try {
       GoogleCredentials credentials =
-          GoogleCredentials.fromStream(getClass().getResourceAsStream("/smart-home-key.json.old"));
+          GoogleCredentials.fromStream(getClass().getResourceAsStream("/smart-home-key.json"));
       actionsApp.setCredentials(credentials);
     } catch (Exception e) {
       LOG.error("couldn't load credentials");

--- a/src/main/java/com/example/SmartHomeUpdateServlet.java
+++ b/src/main/java/com/example/SmartHomeUpdateServlet.java
@@ -55,7 +55,7 @@ public class SmartHomeUpdateServlet extends HttpServlet {
   {
     try {
       GoogleCredentials credentials =
-          GoogleCredentials.fromStream(getClass().getResourceAsStream("/smart-home-key.json.old"));
+          GoogleCredentials.fromStream(getClass().getResourceAsStream("/smart-home-key.json"));
       actionsApp.setCredentials(credentials);
     } catch (Exception e) {
       LOGGER.error("couldn't load credentials");


### PR DESCRIPTION
I'm not sure what the .old extensions were doing but removing them prevent errors with QUERY intents and solves issues relating to devices 'not responding' in the google home app even though they appear to be functioning correctly.